### PR TITLE
fix: handle empty path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ inputs:
     description: 'Plugins file to update'
     required: false
   package-json-dir:
+    default: '.'
     description: 'Directory to look for a package.json file'
     required: false
 runs:

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ type Inputs = {
   githubToken: string
   owner: string
   repo: string
-  packageJsonDirectory?: string
+  packageJsonDirectory: string
   pluginsFile: string
 }
 
@@ -30,7 +30,7 @@ const getInputs = () => {
     'https://list-v2--netlify-plugins.netlify.app/plugins.json'
   const pluginsFile = core.getInput('plugins-file') || process.env.PLUGINS_FILE || 'site/plugins.json'
 
-  const packageJsonDirectory = core.getInput('package-json-dir') || process.env.PACKAGE_JSON_DIRECTORY
+  const packageJsonDirectory = core.getInput('package-json-dir') || process.env.PACKAGE_JSON_DIRECTORY || '.'
 
   return { githubToken, owner, repo, packageJsonDirectory, pluginsDirectory, pluginsFile }
 }


### PR DESCRIPTION
Fixes an issue when we were passing `undefined` cwd to `read-pkg`