### PR TITLE
fix: wait for new version of old package

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -17,9 +17,11 @@ export const validatePackage = async (packageName: string, pluginVersion: string
         core.info(`Found package ${packageAndVersion} in the npm registry`)
         return true
       } catch (error) {
-        const { statusCode } = error as Error & { statusCode: number }
-        if (statusCode) {
-          core.warning(`${packageAndVersion} does no exist in npm registry`)
+        const { statusCode, code } = error as Error & { statusCode?: number; code?: string }
+        // If the package is new and not yet published then there will be a 404.
+        // If the package exists but the version hasn't been published yet then there will be an ETARGET error.
+        if (statusCode || code === 'ETARGET') {
+          core.warning(`${packageAndVersion} does not exist in npm registry yet. Checking again shortly...`)
           return false
         }
         throw error


### PR DESCRIPTION
**Which problem is this pull request solving?**

Often there is a delay before a published package is available on npm. Currently this action attempts to deal with this by retrying if there is an error. However it only catches this for newly-published packages, not new versions of existing packages. 

**Describe the solution you've chosen**

This PR changes the code to catch this situation by handling not just HTTP errors (missing new packages return a 404), but also `ETARGET` errors which mean missing version.

**Describe alternatives you've considered**

Example: Another solution would be [...]

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
![floppy-haired capybara](https://user-images.githubusercontent.com/213306/188610893-430e9850-b6f7-4d42-9c74-dac58022f7af.png)
